### PR TITLE
Remove window sync

### DIFF
--- a/src/compton.c
+++ b/src/compton.c
@@ -3266,7 +3266,6 @@ void update_window_textures(Swiss* em, struct X11Context* xcontext, struct Frame
         // If we fail to bind we just assume that the window must have been
         // closed and keep the old texture
         printf_err("Failed binding some drawable");
-        zone_leave(&ZONE_x_communication);
     }
 
     // @HACK @CORRECTNESS: If we fail to get a texture for the window (for

--- a/src/compton.c
+++ b/src/compton.c
@@ -3261,15 +3261,6 @@ void update_window_textures(Swiss* em, struct X11Context* xcontext, struct Frame
         }
     }
 
-    for_componentsArr(it2, em, req_types) {
-        struct BindsTextureComponent* bindsTexture = swiss_getComponent(em, COMPONENT_BINDS_TEXTURE, it2.id);
-
-        XSyncFence fence = XSyncCreateFence(xcontext->display, bindsTexture->drawable.wid, false);
-        XSyncTriggerFence(xcontext->display, fence);
-        XSyncAwaitFence(xcontext->display, &fence, 1);
-        XSyncDestroyFence(xcontext->display, fence);
-    }
-
     zone_enter(&ZONE_x_communication);
     if(!wd_bind(drawables, drawable_count)) {
         // If we fail to bind we just assume that the window must have been


### PR DESCRIPTION
There doesn't seem to be any reason to do window drawable sync. it doesn't seen to help vsync.