### PR TITLE
Add hotloading of assets.

### DIFF
--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -13,6 +13,8 @@ typedef type_id asset_type;
 typedef void* asset_loader(const char* path);
 typedef void* asset_unloader(const char* path);
 
+void assets_init();
+
 void assets_add_handler_internal(asset_type type, const char* extension,
         asset_loader* loader, asset_unloader* unloader);
 #define assets_add_handler(type, extension, loader, unloader) \
@@ -20,6 +22,7 @@ void assets_add_handler_internal(asset_type type, const char* extension,
             (asset_unloader*)unloader)
 
 void* assets_load(const char* path);
+void assets_hotload();
 
 void assets_add_path(const char* path);
 char* assets_resolve_path(const char* path);

--- a/src/compton.c
+++ b/src/compton.c
@@ -2857,6 +2857,8 @@ session_t * session_init(session_t *ps_old, int argc, char **argv) {
   add_shader_type(&colored_info);
   add_shader_type(&graph_info);
 
+  assets_init();
+
   assets_add_handler(struct shader, "vs", vert_shader_load_file, shader_unload_file);
   assets_add_handler(struct shader, "fs", frag_shader_load_file, shader_unload_file);
   assets_add_handler(struct face, "face", face_load_file, face_unload_file);
@@ -4142,6 +4144,8 @@ void session_run(session_t *ps) {
         zone_enter(&ZONE_input);
 
         while (mainloop(ps));
+
+        assets_hotload();
 
         Swiss* em = &ps->win_list;
 


### PR DESCRIPTION
I've added a new hotloading system based on inotify. Basically, when
loading an asset we add the filepath to inotify, and then reload it
whenever the file changes.

Here we also keep track of what assets are loaded as part of loading
another asset, and add a dependency on those assets. We can then reload
the downstream assets when the upstream changes.

As it stands, asset users are not told their assets have reloaded.