### PR TITLE
Use square face when blitting shadow

### DIFF
--- a/src/shadow.c
+++ b/src/shadow.c
@@ -223,6 +223,8 @@ void windowlist_updateShadow(session_t* ps, Vector* paints) {
 
     glEnable(GL_STENCIL_TEST);
 
+    struct face* face = assets_load("window.face");
+
     for_components(it, &ps->win_list,
         COMPONENT_MUD, COMPONENT_TEXTURED, COMPONENT_PHYSICAL, COMPONENT_SHADOW_DAMAGED, COMPONENT_SHADOW,
         COMPONENT_SHAPED, CQ_END) {
@@ -244,7 +246,7 @@ void windowlist_updateShadow(session_t* ps, Vector* paints) {
 
         glClear(GL_COLOR_BUFFER_BIT);
 
-        draw_tex(shaped->face, &shadow->texture, &VEC3_ZERO, &shadow->effect.size);
+        draw_tex(face, &shadow->texture, &VEC3_ZERO, &shadow->effect.size);
 
         view = old_view;
     }

--- a/src/windowlist.c
+++ b/src/windowlist.c
@@ -74,6 +74,8 @@ void windowlist_drawTransparent(session_t* ps, Vector* transparent) {
     glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
     glBlendEquationSeparate(GL_FUNC_ADD, GL_MAX);
 
+    struct face* face = assets_load("window.face");
+
     size_t index;
     win_id* w_id = vector_getLast(transparent, &index);
     while(w_id != NULL) {
@@ -169,7 +171,7 @@ void windowlist_drawTransparent(session_t* ps, Vector* transparent) {
                 Vector3 tdrpos = vec3_from_vec2(&rpos, z->z);
                 Vector2 rsize = shadow->texture.size;
 
-                draw_rect(shaped->face, shader_type->mvp, tdrpos, rsize);
+                draw_rect(face, shader_type->mvp, tdrpos, rsize);
             }
         }
 


### PR DESCRIPTION
When we are blitting the shadow (to stencil out the window or to render
it from cache) we were previously using the per window face. That
doesn't work if the window has a non-square shape since that will cut
shadow. Instead we can just blit it with the static square face, since
it's already stenciled out and sized correctly.

That's exactly what this change does. Shadows on Xeyes (which have been
broken for a long time) now render correctly.