### PR TITLE
More xorg init

### DIFF
--- a/src/compton.c
+++ b/src/compton.c
@@ -982,8 +982,8 @@ static void ev_unmap_notify(session_t *ps, struct UnmapWin *ev) {
 }
 
 static void getsclient(session_t* ps, struct GetsClient* event) {
-    // We just destroyed the window, so it shouldn't be found
-    assert(find_toplevel(ps, event->client_xid) != -1);
+    // The new client shouldn't be the client of any other window
+    assert(find_toplevel(ps, event->client_xid) == -1);
 
     // Find our new frame
     win *w_frame = find_toplevel2(ps, event->xid);

--- a/src/xorg.c
+++ b/src/xorg.c
@@ -1131,12 +1131,6 @@ static void beginTopWindow(struct X11Context* xctx, Window xid) {
 
     recurseWindow(xctx, xid);
 
-    if(attribs.class != InputOnly) {
-        if(attribs.map_state == IsViewable) {
-            windowMap(xctx, xid);
-        }
-    }
-
     Window client;
     if(findClosestClient(xctx, xid, &client)) {
         createGetsClient(xctx, xid, client);
@@ -1148,13 +1142,11 @@ static void beginTopWindow(struct X11Context* xctx, Window xid) {
         Word_t rc;
         J1S(rc, xctx->bypassed, xid);
         assert(rc != 0);
+    }
 
-        if(isWindowMapped(xctx, xid)) {
-            struct Event event = {
-                .type = ET_BYPASS,
-                .bypass.xid = xid,
-            };
-            pushEvent(xctx, event);
+    if(attribs.class != InputOnly) {
+        if(attribs.map_state == IsViewable) {
+            windowMap(xctx, xid);
         }
     }
 }


### PR DESCRIPTION
We want to initialize a whole bunch more Xorg state during init. This should fix the bug where windows that set the bypass property before compositor init didn't bypass.