### PR TITLE
Unbypass window on delete 

### DIFF
--- a/src/compton.c
+++ b/src/compton.c
@@ -720,6 +720,7 @@ static void redir_start(session_t *ps) {
 
 static void ev_bypass(session_t* ps, struct Bypass* ev) {
     win_id wid = find_win(ps, ev->xid);
+	printf_dbgf("BYPASS %ld", ev->xid);
 
     if(swiss_hasComponent(&ps->win_list, COMPONENT_UNMAP, wid)) {
         swiss_removeComponent(&ps->win_list, COMPONENT_UNMAP, wid);

--- a/src/xorg.c
+++ b/src/xorg.c
@@ -960,10 +960,12 @@ static void fillBuffer(struct X11Context* xctx) {
             XDestroyWindowEvent* ev = (XDestroyWindowEvent *)&raw;
             zone_scope_extra(&ZONE_event_preprocess, "Destroy");
 
+
             Window frame = findRoot(xctx, ev->window);
             bool old_bypassed = isFrameBypassed(xctx, frame);
 
             Word_t rc;
+            J1U(rc, xctx->bypassed, ev->window);
             J1U(rc, xctx->mapped, ev->window);
 
             createDestroyWin(xctx, ev->window);


### PR DESCRIPTION
If the window id was reused by X we kept the old bypass status around.
That meant windows which really shouldn't be bypassed suddenly were, if
another window has previously been bypassed.